### PR TITLE
fix: build issues on some projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ jobs:
 
           # Flag to toggle pushing symbols along with nuget package to the server, disabled by default
           # INCLUDE_SYMBOLS: false
+
+          # Flag to toggle not building the project and letting pack command handle restoring & building, disabled by default
+          # NO_BUILD: false
 ```
 
 - Project gets published only if there's a `NUGET_KEY` configured in the repository
@@ -74,6 +77,7 @@ TAG_FORMAT | `v*` | Format of the git tag, `[*]` gets replaced with actual versi
 NUGET_KEY | | API key to authenticate with NuGet server
 NUGET_SOURCE | `https://api.nuget.org` | NuGet server uri hosting the packages, defaults to https://api.nuget.org
 INCLUDE_SYMBOLS | `false` | Flag to toggle pushing symbols along with nuget package to the server, disabled by default
+NO_BUILD | `false` | Flag to toggle not building the project and letting pack command handle restoring & building, disabled by default
 
 ## Outputs
 

--- a/index.js
+++ b/index.js
@@ -57,6 +57,8 @@ class Action {
 
         fs.readdirSync(".").filter(fn => /\.s?nupkg$/.test(fn)).forEach(fn => fs.unlinkSync(fn))
 
+        this._executeInProcess(`dotnet build -c Release ${this.projectFile}`)
+
         this._executeInProcess(`dotnet pack ${this.includeSymbols ? "--include-symbols -p:SymbolPackageFormat=snupkg" : ""} -c Release ${this.projectFile} -o .`)
 
         const packages = fs.readdirSync(".").filter(fn => fn.endsWith("nupkg"))

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ class Action {
         this.nugetKey = process.env.INPUT_NUGET_KEY || process.env.NUGET_KEY
         this.nugetSource = process.env.INPUT_NUGET_SOURCE || process.env.NUGET_SOURCE
         this.includeSymbols = JSON.parse(process.env.INPUT_INCLUDE_SYMBOLS || process.env.INCLUDE_SYMBOLS)
+        this.noBuild = JSON.parse(process.env.INPUT_NO_BUILD || process.env.NO_BUILD)
     }
 
     _printErrorAndExit(msg) {
@@ -57,7 +58,9 @@ class Action {
 
         fs.readdirSync(".").filter(fn => /\.s?nupkg$/.test(fn)).forEach(fn => fs.unlinkSync(fn))
 
-        this._executeInProcess(`dotnet build -c Release ${this.projectFile}`)
+        if (!this.noBuild) {
+            this._executeInProcess(`dotnet build -c Release ${this.projectFile}`)
+        }
 
         this._executeInProcess(`dotnet pack ${this.includeSymbols ? "--include-symbols -p:SymbolPackageFormat=snupkg" : ""} -c Release ${this.projectFile} -o .`)
 


### PR DESCRIPTION
Reverted removal of `dotnet build` before `dotnet pack`.

`dotnet pack` is still run without `--no-build` flag to ensure packaging of all dlls.