### PR TITLE
fix: Lowercase package name in NuGet API query

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,17 +97,23 @@ class Action {
 
         console.log(`Package Name: ${this.packageName}`)
 
-        https.get(`${this.nugetSource}/v3-flatcontainer/${this.packageName}/index.json`, res => {
+        let url = `${this.nugetSource}/v3-flatcontainer/${this.packageName.toLowerCase()}/index.json`
+        console.log(`Getting versions from ${url}`)
+        https.get(url, res => {
             let body = ""
 
-            if (res.statusCode == 404)
+            if (res.statusCode == 404) {
+                console.log('404 response, assuming new package')
                 this._pushPackage(this.version, this.packageName)
+            }
+                
 
             if (res.statusCode == 200) {
                 res.setEncoding("utf8")
                 res.on("data", chunk => body += chunk)
                 res.on("end", () => {
                     const existingVersions = JSON.parse(body)
+                    console.log(`Versions retrieved: ${existingVersions.versions}`)
                     if (existingVersions.versions.indexOf(this.version) < 0)
                         this._pushPackage(this.version, this.packageName)
                 })


### PR DESCRIPTION
Uppercase package names don't play nice with the NuGet API as mentioned here: https://github.com/NuGet/NuGetGallery/issues/9105

Without fix:
```
Version: 1.0.5
Package Name: Serilog.Enrichers.ShortTypeName
Getting versions from https://api.nuget.org/v3-flatcontainer/Serilog.Enrichers.ShortTypeName/index.json
404 response, assuming new package
✨ found new version (1.0.5) of Serilog.Enrichers.ShortTypeName
NuGet Source: https://api.nuget.org/
```

With fix:
```
Version: 1.0.5
Package Name: Serilog.Enrichers.ShortTypeName
Getting versions from https://api.nuget.org/v3-flatcontainer/serilog.enrichers.shorttypename/index.json
Versions retrieved: 1.0.0,1.0.1,1.0.2,1.0.3,1.0.4,1.0.5
```